### PR TITLE
  fix(android): barcode scan returns empty array despite successful detection

### DIFF
--- a/android/src/main/java/com/imagecodescanner/ImageCodeScannerModule.kt
+++ b/android/src/main/java/com/imagecodescanner/ImageCodeScannerModule.kt
@@ -250,7 +250,8 @@ class ImageCodeScannerModule(reactContext: ReactApplicationContext) :
                   }
                   .filter { it != null }
                 
-                val arr = Arguments.fromList(codes)
+                val arr = Arguments.createArray()
+                codes.forEach { code -> arr.pushMap(code) }
                 promise.resolve(arr)
               } else {
                 // No barcodes found, try next preprocessing


### PR DESCRIPTION
 ## Description
  Fixes Android barcode scanning returning empty array despite successful detection.

  ## Problem
  `Arguments.fromList()` does not properly handle `List<WritableMap>`, causing it to return an empty array even when barcodes are successfully detected on Android.

  ## Solution
  Changed to use `Arguments.createArray()` with `pushMap()` to properly handle `WritableMap` objects, which is the correct way to pass complex objects through the React Native bridge.

  ## Changes
  - Modified `ImageCodeScannerModule.kt` lines 253-254
  - Replaced `Arguments.fromList(codes)` with `Arguments.createArray()` + forEach loop with `pushMap()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal barcode result processing in the image scanner module for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->