### PR TITLE
fix(android): replace BaseReactPackage with ReactPackage for RN 0.70-0.73 compatibility

### DIFF
--- a/android/src/main/java/com/imagecodescanner/ImageCodeScannerPackage.kt
+++ b/android/src/main/java/com/imagecodescanner/ImageCodeScannerPackage.kt
@@ -1,33 +1,22 @@
 package com.imagecodescanner
 
-import com.facebook.react.BaseReactPackage
+import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.module.model.ReactModuleInfo
-import com.facebook.react.module.model.ReactModuleInfoProvider
-import java.util.HashMap
+import com.facebook.react.uimanager.ViewManager
 
-class ImageCodeScannerPackage : BaseReactPackage() {
-  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
-    return if (name == ImageCodeScannerModule.NAME) {
-      ImageCodeScannerModule(reactContext)
-    } else {
-      null
-    }
+class ImageCodeScannerPackage : ReactPackage {
+
+  override fun createNativeModules(
+    reactContext: ReactApplicationContext
+  ): List<NativeModule> {
+    return listOf(ImageCodeScannerModule(reactContext))
   }
 
-  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
-    return ReactModuleInfoProvider {
-      val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
-      moduleInfos[ImageCodeScannerModule.NAME] = ReactModuleInfo(
-        ImageCodeScannerModule.NAME,
-        ImageCodeScannerModule.NAME,
-        false,  // canOverrideExistingModule
-        false,  // needsEagerInit
-        false,  // isCxxModule
-        true // isTurboModule
-      )
-      moduleInfos
-    }
+  override fun createViewManagers(
+    reactContext: ReactApplicationContext
+  ): List<ViewManager<*, *>> {
+    return emptyList()
   }
+
 }


### PR DESCRIPTION
  ## Description
  Fixes build failure in React Native 0.70-0.73 caused by `BaseReactPackage` which doesn't exist in these versions.

  ## Problem
  `BaseReactPackage` was introduced in React Native 0.74. Using it causes build errors in RN 0.70-0.73:
  Unresolved reference: BaseReactPackage

  ## Solution
  Replace `BaseReactPackage` with direct `ReactPackage` interface implementation, which exists in all React Native versions.

  ## Changes
  - Changed `ImageCodeScannerPackage` from extending `BaseReactPackage` to implementing `ReactPackage`
  - Replaced `getModule()` and `getReactModuleInfoProvider()` with `createNativeModules()` and `createViewManagers()`
  - Maintains identical functionality with broader version compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module initialization architecture to improve code maintainability and align with current framework standards. No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->