### PR TITLE
ci: pin iOS build Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,9 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-turborepo-ios-
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-turborepo-ios-
 
       - name: Check turborepo cache for iOS
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
-      XCODE_VERSION: latest-stable
+      XCODE_VERSION: '16.4'
       TURBO_CACHE_DIR: .turbo/ios
       CI: 1
     steps:


### PR DESCRIPTION
## Summary
- pin the iOS CI job to macOS 15
- pin setup-xcode to Xcode 16.4 instead of latest-stable

## Why
The example app uses Expo SDK 52 / React Native 0.76.9. Using macos-latest with latest-stable can select a newer Xcode toolchain and fail while compiling React Native pods such as fmt.

## Verification
- Parsed .github/workflows/ci.yml with Ruby YAML loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the iOS CI build workflow to use a fixed macOS runner and Xcode version for more consistent build results.
  * Improved build cache segregation by incorporating the selected Xcode version, reducing cross-version cache interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->